### PR TITLE
CORS & remove unnecessary parameter from client

### DIFF
--- a/modules/ipfs-cpinner-client/README.md
+++ b/modules/ipfs-cpinner-client/README.md
@@ -33,9 +33,9 @@ const storage: ClientKeyValueStorage = myCustomStorage
 const serviceDid = 'did:ethr:rsk:0x123456789....abc'
 const address = '0xabcdef....123' // user's address
 const did = `did:ethr:rsk:${address}`
-const signer = (data: string) => window.ethereum.request({ method: 'personal_sign', params: [address, data] }) // this is an example with Metamask
+const rpcPersonalSign = (data: string) => window.ethereum.request({ method: 'personal_sign', params: [address, data] }) // this is an example with Metamask
 
-const client = new DataVaultWebClient({ serviceUrl, did, signer, serviceDid, storage })
+const client = new DataVaultWebClient({ serviceUrl, did, rpcPersonalSign, serviceDid, storage })
 ```
 
 ### Get
@@ -55,9 +55,9 @@ const credentials = await client.get({ did, key })
 ```typescript
 import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 
-const client = new DataVaultWebClient({ serviceUrl, did, signer, serviceDid })
+const client = new DataVaultWebClient({ serviceUrl, did, rpcPersonalSign, serviceDid })
 
-const keys = await client.getKeys({ did })
+const keys = await client.getKeys()
 ```
 
 ### Create
@@ -65,7 +65,7 @@ const keys = await client.getKeys({ did })
 ```typescript
 import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 
-const client = new DataVaultWebClient({ serviceUrl, did, signer, serviceDid })
+const client = new DataVaultWebClient({ serviceUrl, did, rpcPersonalSign, serviceDid })
 
 const key = 'MyKey'
 const content = 'this is my content'
@@ -78,7 +78,7 @@ const id = await client.create({ key, content })
 ```typescript
 import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 
-const client = new DataVaultWebClient({ serviceUrl, did, signer, serviceDid })
+const client = new DataVaultWebClient({ serviceUrl, did, rpcPersonalSign, serviceDid })
 
 const key = 'MyKey'
 const content = 'this is my content'
@@ -91,7 +91,7 @@ const id = await client.swap({ key, content })
 ```typescript
 import DataVaultWebClient from '@rsksmart/ipfs-cpinner-client'
 
-const client = new DataVaultWebClient({ serviceUrl, did, signer, serviceDid })
+const client = new DataVaultWebClient({ serviceUrl, did, rpcPersonalSign, serviceDid })
 
 const key = 'MyKey'
 

--- a/modules/ipfs-cpinner-client/package.json
+++ b/modules/ipfs-cpinner-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/ipfs-cpinner-client",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1-beta.2",
   "description": "RIF Data Vault - IPFS centralized pinner client",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/modules/ipfs-cpinner-client/package.json
+++ b/modules/ipfs-cpinner-client/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/rsksmart/rif-data-vault#readme",
   "devDependencies": {
     "@rsksmart/ipfs-cpinner-provider": "0.1.1-beta.1",
-    "@rsksmart/ipfs-cpinner-service": "0.1.1-beta.1",
+    "@rsksmart/ipfs-cpinner-service": "0.1.1-beta.2",
     "@rsksmart/rif-id-ethr-did": "^0.1.0",
     "@rsksmart/rif-id-mnemonic": "^0.1.0",
     "@types/axios": "^0.14.0",

--- a/modules/ipfs-cpinner-client/src/index.ts
+++ b/modules/ipfs-cpinner-client/src/index.ts
@@ -6,7 +6,7 @@ import {
   AuthenticationManager,
   ClientKeyValueStorage, CreateContentPayload, CreateContentResponse,
   DeleteTokenPayload, GetContentPayload, Config,
-  SwapContentPayload, SwapContentResponse, GetKeysPayload
+  SwapContentPayload, SwapContentResponse
 } from './types'
 
 const ClientKeyValueStorageFactory = {
@@ -31,8 +31,8 @@ export default class {
       .then(({ content }) => content.length && content)
   }
 
-  getKeys ({ did }: GetKeysPayload): Promise<string[]> {
-    const { serviceUrl } = this.config
+  getKeys (): Promise<string[]> {
+    const { serviceUrl, did } = this.config
 
     return this.getAccessToken()
       .then(accessToken => axios.get(

--- a/modules/ipfs-cpinner-client/src/types.ts
+++ b/modules/ipfs-cpinner-client/src/types.ts
@@ -1,4 +1,3 @@
-export type GetKeysPayload = { did: string }
 export type GetContentPayload = { did: string, key: string }
 export type CreateContentPayload = { key: string, content: string }
 export type CreateContentResponse = { id: string }

--- a/modules/ipfs-cpinner-client/test/get-keys.test.ts
+++ b/modules/ipfs-cpinner-client/test/get-keys.test.ts
@@ -39,9 +39,9 @@ describe('get keys', function (this: {
   })
 
   test('should return an empty array if no keys', async () => {
-    const { did, dataVaultClient } = await setupDataVaultClient(this.serviceUrl, this.serviceDid)
+    const { dataVaultClient } = await setupDataVaultClient(this.serviceUrl, this.serviceDid)
 
-    const keys = await dataVaultClient.getKeys({ did })
+    const keys = await dataVaultClient.getKeys()
 
     expect(keys).toEqual([])
   })
@@ -54,7 +54,7 @@ describe('get keys', function (this: {
 
     await this.ipfsPinnerProvider.create(did, key, content)
 
-    const keys = await dataVaultClient.getKeys({ did })
+    const keys = await dataVaultClient.getKeys()
 
     expect(keys).toEqual([key])
   })

--- a/modules/ipfs-cpinner-client/test/sandbox-env.test.ts
+++ b/modules/ipfs-cpinner-client/test/sandbox-env.test.ts
@@ -6,7 +6,7 @@ jest.setTimeout(12000)
 
 // this are integration tests
 
-describe.skip('sandbox environment', function (this: {
+describe('sandbox environment', function (this: {
   did: string
 }) {
   const setup = async (): Promise<DataVaultWebClient> => {
@@ -15,8 +15,8 @@ describe.skip('sandbox environment', function (this: {
     const rpcPersonalSign = clientIdentity.rpcPersonalSign
 
     // COMPLETE WITH YOUR SANDBOX ENVIRONMENT VALUES
-    const serviceDid = ''
-    const serviceUrl = ''
+    const serviceDid = 'did:ethr:rsk:testnet:0x285B30492a3F444d78f75261A35cB292Fc8F41A6'
+    const serviceUrl = 'http://ec2-3-131-142-122.us-east-2.compute.amazonaws.com:5107'
 
     return new DataVaultWebClient({ serviceUrl, did: this.did, rpcPersonalSign, serviceDid })
   }
@@ -32,6 +32,19 @@ describe.skip('sandbox environment', function (this: {
     const { id } = await client.create({ key, content })
 
     expect(id).toBeTruthy()
+  })
+
+  test('should get all keys', async () => {
+    const client = await setup()
+
+    const key = 'AKey'
+    const content = 'the content'
+
+    await client.create({ key, content })
+
+    const keys = await client.getKeys()
+
+    expect(keys).toEqual([key])
   })
 
   test('should get a content', async () => {

--- a/modules/ipfs-cpinner-service/package-lock.json
+++ b/modules/ipfs-cpinner-service/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rsksmart/ipfs-cpinner-service",
-	"version": "0.1.0",
+	"version": "0.1.1-beta.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/modules/ipfs-cpinner-service/package.json
+++ b/modules/ipfs-cpinner-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/ipfs-cpinner-service",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1-beta.2",
   "description": "RIF Identity - IPFS Centralized Pinner Service",
   "private": true,
   "main": "lib/index.js",
@@ -40,21 +40,21 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
-    "@rsksmart/rif-id-mnemonic": "^0.1.0",
-    "@types/supertest": "^2.0.10",
-    "sqlite3": "^5.0.0",
-    "supertest": "^5.0.0",
-    "typeorm": "0.2.28",
-    "typescript": "^4.0.5",
     "@rsksmart/ipfs-cpinner-provider": "0.1.0",
+    "@rsksmart/rif-id-mnemonic": "^0.1.0",
     "@rsksmart/rif-node-utils": "0.0.3",
     "@types/body-parser": "^1.19.0",
     "@types/cors": "^2.8.8",
     "@types/express": "^4.17.8",
+    "@types/supertest": "^2.0.10",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
+    "ethereumjs-util": "^7.0.7",
     "express": "^4.17.1",
-    "ethereumjs-util": "^7.0.7"
+    "sqlite3": "^5.0.0",
+    "supertest": "^5.0.0",
+    "typeorm": "0.2.28",
+    "typescript": "^4.0.5"
   }
 }

--- a/modules/ipfs-cpinner-service/src/index.ts
+++ b/modules/ipfs-cpinner-service/src/index.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv'
 import express from 'express'
 import bodyParser from 'body-parser'
+import cors from 'cors'
 import setupApp, { AuthConfig } from './setup'
 import { loggerFactory } from '@rsksmart/rif-node-utils'
 import { rskDIDFromPrivateKey, rskTestnetDIDFromPrivateKey } from '@rsksmart/rif-id-ethr-did'
@@ -42,6 +43,7 @@ const config: AuthConfig = {
 
 const app = express()
 app.use(bodyParser.json())
+app.use(cors())
 
 createConnection({
   type: 'sqlite',


### PR DESCRIPTION
- [x] Add `cors` to service
- [x] Bumped versions of the service and the client
- [x] Removed unnecessary parameter from `getKeys` in the client. As it is a protected endpoint, it takes the user did from the constructor of the class
- [x] Fixed `signer` typo in the client README