### PR TITLE
Remove did parameter from the service when getting keys by did

### DIFF
--- a/modules/ipfs-cpinner-client/src/index.ts
+++ b/modules/ipfs-cpinner-client/src/index.ts
@@ -32,11 +32,11 @@ export default class {
   }
 
   getKeys (): Promise<string[]> {
-    const { serviceUrl, did } = this.config
+    const { serviceUrl } = this.config
 
     return this.getAccessToken()
       .then(accessToken => axios.get(
-        `${serviceUrl}/keys/${did}`,
+        `${serviceUrl}/keys`,
         { headers: { Authorization: `DIDAuth ${accessToken}` } })
       )
       .then(res => res.status === 200 && !!res.data && res.data.keys)

--- a/modules/ipfs-cpinner-service/src/api.ts
+++ b/modules/ipfs-cpinner-service/src/api.ts
@@ -44,8 +44,8 @@ export function setupPermissionedApi (app: Express, provider: IpfsPinnerProvider
     }
   })
 
-  app.get('/keys/:did', async (req: AuthenticatedRequest, res: Response) => {
-    const { did } = req.params
+  app.get('/keys', async (req: AuthenticatedRequest, res) => {
+    const { did } = req.user
 
     logger.info(`Retrieving keys from ${did}`)
 

--- a/modules/ipfs-cpinner-service/test/api.permissioned.delete.test.ts
+++ b/modules/ipfs-cpinner-service/test/api.permissioned.delete.test.ts
@@ -9,7 +9,6 @@ import bodyParser from 'body-parser'
 describe('PUT', function (this: {
   app: Express,
   did: string
-  middleware: (req, res, next) => any,
   dbConnection: Connection,
   dbName: string,
   provider: IpfsPinnerProvider
@@ -23,13 +22,13 @@ describe('PUT', function (this: {
 
   beforeEach(() => {
     this.did = 'did:ethr:rsk:testnet:0xce83da2a364f37e44ec1a17f7f453a5e24395c70'
-    this.middleware = (req, res, next) => {
+    const middleware = (req, res, next) => {
       req.user = { did: this.did }
       next()
     }
     this.app = express()
     this.app.use(bodyParser.json())
-    this.app.use(this.middleware)
+    this.app.use(middleware)
   })
 
   afterEach(() => deleteDatabase(this.dbConnection, this.dbName))

--- a/modules/ipfs-cpinner-service/test/api.permissioned.post.test.ts
+++ b/modules/ipfs-cpinner-service/test/api.permissioned.post.test.ts
@@ -11,7 +11,6 @@ const maxStorage = 10000
 describe('POST', function (this: {
   app: Express,
   did: string
-  middleware: (req, res, next) => any,
   dbConnection: Connection,
   dbName: string,
   provider: IpfsPinnerProvider
@@ -33,13 +32,13 @@ describe('POST', function (this: {
 
   beforeEach(() => {
     this.did = 'did:ethr:rsk:testnet:0xce83da2a364f37e44ec1a17f7f453a5e24395c70'
-    this.middleware = (req, res, next) => {
+    const middleware = (req, res, next) => {
       req.user = { did: this.did }
       next()
     }
     this.app = express()
     this.app.use(bodyParser.json())
-    this.app.use(this.middleware)
+    this.app.use(middleware)
   })
 
   afterEach(() => deleteDatabase(this.dbConnection, this.dbName))

--- a/modules/ipfs-cpinner-service/test/api.permissioned.put.test.ts
+++ b/modules/ipfs-cpinner-service/test/api.permissioned.put.test.ts
@@ -12,7 +12,6 @@ const maxStorage = 1000
 describe('PUT', function (this: {
   app: Express,
   did: string
-  middleware: (req, res, next) => any,
   dbConnection: Connection,
   dbName: string,
   provider: IpfsPinnerProvider
@@ -34,13 +33,13 @@ describe('PUT', function (this: {
 
   beforeEach(() => {
     this.did = 'did:ethr:rsk:testnet:0xce83da2a364f37e44ec1a17f7f453a5e24395c70'
-    this.middleware = (req, res, next) => {
+    const middleware = (req, res, next) => {
       req.user = { did: this.did }
       next()
     }
     this.app = express()
     this.app.use(bodyParser.json())
-    this.app.use(this.middleware)
+    this.app.use(middleware)
   })
 
   afterEach(() => deleteDatabase(this.dbConnection, this.dbName))

--- a/modules/ipfs-cpinner-service/test/api.permissioned.storage.test.ts
+++ b/modules/ipfs-cpinner-service/test/api.permissioned.storage.test.ts
@@ -9,7 +9,6 @@ import request from 'supertest'
 describe('storage', function (this: {
   app: Express,
   did: string
-  middleware: (req, res, next) => any,
   dbConnection: Connection,
   dbName: string,
   provider: IpfsPinnerProvider
@@ -25,13 +24,13 @@ describe('storage', function (this: {
 
   beforeEach(() => {
     this.did = 'did:ethr:rsk:testnet:0xce83da2a364f37e44ec1a17f7f453a5e24395c70'
-    this.middleware = (req, res, next) => {
+    const middleware = (req, res, next) => {
       req.user = { did: this.did }
       next()
     }
     this.app = express()
     this.app.use(bodyParser.json())
-    this.app.use(this.middleware)
+    this.app.use(middleware)
   })
 
   afterEach(() => deleteDatabase(this.dbConnection, this.dbName))

--- a/modules/ipfs-cpinner-service/test/setup.test.ts
+++ b/modules/ipfs-cpinner-service/test/setup.test.ts
@@ -65,10 +65,10 @@ describe('setup api with authentication', function (this: {
   })
 
   describe('GET /keys/:did', () => {
-    test('should respond 401 with no access token', () => request(this.app).get(`/keys/${this.clientDid}`).expect(401))
+    test('should respond 401 with no access token', () => request(this.app).get('/keys').expect(401))
 
     test('should respond 200 with access token', () => request(this.app)
-      .get(`/keys/${this.clientDid}`)
+      .get('/keys')
       .set('Authorization', `DIDAuth ${this.accessToken}`)
       .expect(200)
       .then(response => {


### PR DESCRIPTION
Vulnerability: any logged user was able to see the keys of any other did
Fix: remove `did` from the path and get it from the logged token.

Also, remove unnecessary middleware field from `this` in many tests