### PR TITLE
Fix webpack build so it exports the named objects

### DIFF
--- a/modules/ipfs-cpinner-client/package-lock.json
+++ b/modules/ipfs-cpinner-client/package-lock.json
@@ -7345,16 +7345,6 @@
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
 			"dev": true
 		},
-		"stream-browserify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-			"integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
-			"dev": true,
-			"requires": {
-				"inherits": "~2.0.4",
-				"readable-stream": "^3.5.0"
-			}
-		},
 		"stream-each": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",

--- a/modules/ipfs-cpinner-client/package.json
+++ b/modules/ipfs-cpinner-client/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@rsksmart/ipfs-cpinner-client",
-  "version": "0.1.1-beta.6",
+  "version": "0.1.1-beta.7",
   "description": "RIF Data Vault - IPFS centralized pinner client",
-  "main": "dist/index.js",
+  "main": "dist/bundle.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "webpack"

--- a/modules/ipfs-cpinner-client/webpack.config.js
+++ b/modules/ipfs-cpinner-client/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('path')
 
 module.exports = {
   entry: './src/index.ts',
@@ -8,9 +8,9 @@ module.exports = {
       {
         test: /\.ts$/,
         use: 'ts-loader',
-        exclude: /node_modules/,
-      },
-    ],
+        exclude: /node_modules/
+      }
+    ]
   },
   resolve: {
     extensions: ['.ts', '.js']
@@ -18,5 +18,6 @@ module.exports = {
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
-  },
-};
+    libraryTarget: 'umd'
+  }
+}


### PR DESCRIPTION
Set the `libraryTarget` to `'umd'` so it exports the `AuthManager` and `EncryptionManager` as expected