### PR TITLE
Check if the content is encrypted before trying to decrypt it

### DIFF
--- a/modules/ipfs-cpinner-client/src/encryption-manager/index.ts
+++ b/modules/ipfs-cpinner-client/src/encryption-manager/index.ts
@@ -4,10 +4,25 @@ import { DecryptFn, EncryptionManagerConfig, GetEncryptionPublicKeyFn } from './
 
 class EncryptionManager {
   getEncryptionPublicKey: GetEncryptionPublicKeyFn
-  public decrypt: DecryptFn
+  private decryptInWallet: DecryptFn
   constructor ({ getEncryptionPublicKey, decrypt }: EncryptionManagerConfig) {
     this.getEncryptionPublicKey = getEncryptionPublicKey
-    this.decrypt = decrypt
+    this.decryptInWallet = decrypt
+  }
+
+  public decrypt = (data: string): Promise<string> => {
+    const hexaRegex = /^0x[0-9a-fA-F]+$/
+
+    // if not an hexadecimal, it means it is not encrypted, return the same data
+    if (!this.decryptInWallet || !hexaRegex.test(data)) return Promise.resolve(data)
+
+    const cipherText = Buffer.from(data.substr(2), 'hex').toString('utf8')
+
+    // we assume that if the text contains "version":"x25519-xsalsa20-poly1305", it is a cipherText that can be decrypted in a wallet.
+    // more information in https://docs.metamask.io/guide/rpc-api.html#eth-getencryptionpublickey
+    if (cipherText.indexOf('"version":"x25519-xsalsa20-poly1305"') > 0) return this.decryptInWallet(data)
+
+    return Promise.resolve(data)
   }
 
   public encrypt = (data: string): Promise<string> => this.getEncryptionPublicKey()

--- a/modules/ipfs-cpinner-client/test/encryption-manager.test.ts
+++ b/modules/ipfs-cpinner-client/test/encryption-manager.test.ts
@@ -86,13 +86,35 @@ describe('decrypt', () => {
     expect(mockedFn.mock.calls.length).toBe(1)
   })
 
-  test('should throw an error if no function to decrypt', async () => {
-    const { decrypt } = new EncryptionManager({
+  test('should return the received string if it is an hexa but there is not function to decrypt', async () => {
+    const { encrypt, decrypt } = new EncryptionManager({
       getEncryptionPublicKey: getEncryptionPublicKeyTestFn,
       decrypt: undefined
     })
 
-    expect(() => decrypt('Will fail')).toThrowError()
+    const content = 'Will return this text encrypted'
+    const encryptedHex = await encrypt(content)
+    const decrypted = await decrypt(encryptedHex)
+
+    expect(decrypted).toEqual(encryptedHex)
+  })
+
+  test('should not decrypt if the data is not an hexadecimal string', async () => {
+    const { decrypt } = new EncryptionManager({ decrypt: decryptTestFn })
+
+    const content = 'This is a test and is not an hexa'
+    const decrypted = await decrypt(content)
+
+    expect(decrypted).toEqual(content)
+  })
+
+  test('should not decrypt if the data is an hexadecimal but it does not represent a ciphertext', async () => {
+    const { decrypt } = new EncryptionManager({ decrypt: decryptTestFn })
+
+    const content = '0x1234567890'
+    const decrypted = await decrypt(content)
+
+    expect(decrypted).toEqual(content)
   })
 
   test('should create auth manager from web3 provider', async () => {


### PR DESCRIPTION
Added an extra step in the `EncryptionManager` before using the provided `decrypt` function.

It checks if the data is an hexa and then if its representation is a ciphertext. If it is not a cipher, it returns the received string and do not executes the `decrypt` function received.