### PR TITLE
Switch account and message for personal_sign

### DIFF
--- a/modules/ipfs-cpinner-client/README.md
+++ b/modules/ipfs-cpinner-client/README.md
@@ -38,7 +38,7 @@ const address = '0xabcdef....123' // user's address
 const did = `did:ethr:rsk:${address}`
 
 // these are examples with Metamask
-const personalSign = (data: string) => window.ethereum.request({ method: 'personal_sign', params: [address, data] })
+const personalSign = (data: string) => window.ethereum.request({ method: 'personal_sign', params: [data, address] })
 const decrypt = (hexCypher: string) => window.ethereum.request({ method: 'eth_decrypt', params: [hexCypher, address] })
 const getEncryptionPublicKey = () => window.ethereum.request.request({ method: 'eth_getEncryptionPublicKey', params: [address] })
 

--- a/modules/ipfs-cpinner-client/package-lock.json
+++ b/modules/ipfs-cpinner-client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@rsksmart/ipfs-cpinner-client",
-	"version": "0.1.1-beta.11",
+	"version": "0.1.1-beta.13",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rsksmart/ipfs-cpinner-client",
-			"version": "0.1.1-beta.11",
+			"version": "0.1.1-beta.13",
 			"license": "MIT",
 			"dependencies": {
 				"axios": "^0.21.1",

--- a/modules/ipfs-cpinner-client/package.json
+++ b/modules/ipfs-cpinner-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/ipfs-cpinner-client",
-  "version": "0.1.1-beta.12",
+  "version": "0.1.1-beta.13",
   "description": "RIF Data Vault - IPFS centralized pinner client",
   "main": "dist/bundle.js",
   "types": "lib/index.d.ts",
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/rsksmart/rif-data-vault#readme",
   "devDependencies": {
-    "@rsksmart/ipfs-cpinner-provider": "0.1.1-beta.12",
-    "@rsksmart/ipfs-cpinner-service": "0.1.1-beta.12",
+    "@rsksmart/ipfs-cpinner-provider": "0.1.1-beta.13",
+    "@rsksmart/ipfs-cpinner-service": "0.1.1-beta.13",
     "@rsksmart/rif-id-ethr-did": "^0.1.0",
     "@rsksmart/rif-id-mnemonic": "^0.1.0",
     "@types/axios": "^0.14.0",

--- a/modules/ipfs-cpinner-client/src/auth-manager/index.ts
+++ b/modules/ipfs-cpinner-client/src/auth-manager/index.ts
@@ -92,7 +92,7 @@ class AuthManager {
       ...config,
       personalSign: (data: string) => provider.request({
         method: 'personal_sign',
-        params: [accounts[0], data]
+        params: [data, accounts[0]]
       })
     }))
   }

--- a/modules/ipfs-cpinner-client/src/encryption-manager/aes.ts
+++ b/modules/ipfs-cpinner-client/src/encryption-manager/aes.ts
@@ -8,10 +8,10 @@ import WordArray from 'crypto-js/lib-typedarrays'
 import { Web3Provider } from '../web3provider/types'
 
 export const generateKeyViaRPC = (provider: Web3Provider, account: string) => provider.request({
-  method: 'personal_sign', params: [account, 'The website wants permission to access and manage your data vault']
+  method: 'personal_sign', params: ['The website wants permission to access and manage your data vault', account]
 }).then(sig => provider.request({
   // make sure the wallet signing is deterministic
-  method: 'personal_sign', params: [account, 'The website wants permission to access and manage your data vault']
+  method: 'personal_sign', params: ['The website wants permission to access and manage your data vault', account]
 }).then(sig2 => {
   if (sig2 !== sig) throw new Error('Sorry, your wallet does not support encryption. You cannot access your Data Vault')
   // Check the size of r and s - // 0x r(32) s(32) v(1)

--- a/modules/ipfs-cpinner-client/src/web3provider/types.ts
+++ b/modules/ipfs-cpinner-client/src/web3provider/types.ts
@@ -1,6 +1,6 @@
 export interface Web3Provider {
   request(args: { method: 'eth_accounts' }): Promise<string[]>
-  request(args: { method: 'personal_sign', params: [account: string, data: string] }): Promise<string>
+  request(args: { method: 'personal_sign', params: [data: string, account: string] }): Promise<string>
   request(args: { method: 'eth_getEncryptionPublicKey', params: [account: string] }): Promise<string>
   request(args: { method: 'eth_decrypt', params: [cipher: string, account: string] }): Promise<string>
 }

--- a/modules/ipfs-cpinner-client/test/web3-provider.ts
+++ b/modules/ipfs-cpinner-client/test/web3-provider.ts
@@ -22,8 +22,8 @@ export class Provider implements Web3Provider {
       return Promise.resolve([this.account])
     }
     if (method === 'personal_sign') {
-      this.validateAccount(params[0])
-      return Promise.resolve(this.personalSign(params[1]))
+      this.validateAccount(params[1])
+      return Promise.resolve(this.personalSign(params[0]))
     }
     if (method === 'eth_getEncryptionPublicKey') {
       this.validateAccount(params[0])

--- a/modules/ipfs-cpinner-provider/package-lock.json
+++ b/modules/ipfs-cpinner-provider/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@rsksmart/ipfs-cpinner-provider",
-	"version": "0.1.1-beta.11",
+	"version": "0.1.1-beta.13",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rsksmart/ipfs-cpinner-provider",
-			"version": "0.1.1-beta.11",
+			"version": "0.1.1-beta.13",
 			"license": "MIT",
 			"dependencies": {
 				"ipfs-http-client": "^47.0.1",

--- a/modules/ipfs-cpinner-provider/package.json
+++ b/modules/ipfs-cpinner-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/ipfs-cpinner-provider",
-  "version": "0.1.1-beta.12",
+  "version": "0.1.1-beta.13",
   "description": "RIF Identity - IPFS Centralized Pinner Provider",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/modules/ipfs-cpinner-service/package-lock.json
+++ b/modules/ipfs-cpinner-service/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@rsksmart/ipfs-cpinner-service",
-	"version": "0.1.1-beta.11",
+	"version": "0.1.1-beta.13",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@rsksmart/ipfs-cpinner-service",
-			"version": "0.1.1-beta.11",
+			"version": "0.1.1-beta.13",
 			"license": "MIT",
 			"dependencies": {
 				"@rsksmart/express-did-auth": "0.1.4",

--- a/modules/ipfs-cpinner-service/package.json
+++ b/modules/ipfs-cpinner-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/ipfs-cpinner-service",
-  "version": "0.1.1-beta.12",
+  "version": "0.1.1-beta.13",
   "description": "RIF Identity - IPFS Centralized Pinner Service",
   "private": true,
   "main": "lib/index.js",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/rsksmart/rif-data-vault#readme",
   "dependencies": {
-    "@rsksmart/ipfs-cpinner-provider": "0.1.1-beta.12",
+    "@rsksmart/ipfs-cpinner-provider": "0.1.1-beta.13",
     "@rsksmart/rif-id-ethr-did": "^0.1.0",
     "@rsksmart/rif-node-utils": "0.0.3",
     "@rsksmart/express-did-auth": "0.1.4",


### PR DESCRIPTION
Fixes issue with WalletConnect where it was not signing the messages. 

This change was tested in the Id Manager using `yarn link`. Tested with WalletConnect and then Nifty wallet. 

For reference see these two changes
 - https://github.com/rsksmart/rif-identity-manager/blob/develop/src/app/state/operations/datavault.ts#L20
 - https://github.com/rsksmart/rLogin/blob/develop/src/lib/data-vault.ts#L8