### PR TITLE
Update Node to v12

### DIFF
--- a/modules/ipfs-cpinner-service/Dockerfile
+++ b/modules/ipfs-cpinner-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12
 
 WORKDIR /app
 


### PR DESCRIPTION
One of the libraries uses TextDecoder as global and that was added in v11. Ref: https://nodejs.org/api/util.html#util_new_textdecoder_encoding_options